### PR TITLE
Fix for MSVC 9.0 warning C4913

### DIFF
--- a/include/boost/array.hpp
+++ b/include/boost/array.hpp
@@ -115,13 +115,15 @@ namespace boost {
 
         // operator[]
         reference operator[](size_type i) 
-        { 
-            return BOOST_ASSERT_MSG( i < N, "out of range" ), elems[i]; 
+        {
+            BOOST_ASSERT_MSG(i < N, "out of range");
+            return elems[i]; 
         }
         
         /*BOOST_CONSTEXPR*/ const_reference operator[](size_type i) const 
-        {     
-            return BOOST_ASSERT_MSG( i < N, "out of range" ), elems[i]; 
+        {
+            BOOST_ASSERT_MSG(i < N, "out of range");
+            return elems[i]; 
         }
 
         // at() with range check


### PR DESCRIPTION
MSVC emitted the warning
```
user defined binary operator ',' exists but no overload could convert all operands, default built-in binary operator ',' used
```
for the `operator[]`. The fix splits the `BOOST_ASSERT_MSG` usage and the element access to two statements.