### PR TITLE
Fix compilation for Oracle Studio 12.5

### DIFF
--- a/include/boost/array.hpp
+++ b/include/boost/array.hpp
@@ -373,7 +373,7 @@ namespace boost {
 
    // Specific for boost::array: simply returns its elems data member.
    template <typename T, std::size_t N>
-   typename const detail::c_array<T,N>::type& get_c_array(const boost::array<T,N>& arg)
+   typename detail::c_array<T,N>::type const& get_c_array(const boost::array<T,N>& arg)
    {
        return arg.elems;
    }


### PR DESCRIPTION
The compiler expects a qualified dependent name after `typename`, so move `const` after the name.

This is supposed to fix compiler errors like this:

`"../boost/array.hpp", line 376: Error: expected a qualified name after "typename".`

http://www.boost.org/development/tests/develop/developer/output/oracle-intel-S2-12-5_next-cpp11-boost-bin-v2-libs-atomic-test-atomicity-test-sun-12-5_next_cpp11-release-threading-multi.html