### PR TITLE
Replace Boost.Test with lightweight_test from Boost.Core

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,24 +2,17 @@
 #~ Distributed under the Boost Software License, Version 1.0.
 #~ (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-import testing ;
-
-alias unit_test_framework
-    : # sources
-        /boost//unit_test_framework
-    ;        
-
 test-suite array :
-    [ run array0.cpp unit_test_framework  : : : : array0 ]
+    [ run array0.cpp ]
     [ run array1.cpp ]
     [ run array2.cpp ]
     [ run array3.cpp ]
     [ run array4.cpp ]
     [ run array5.cpp ]
-    [ run array6.cpp unit_test_framework  : : : : array6 ]
-    [ run array7.cpp unit_test_framework  : : : : array7 ]
-#    [ run array_constexpr.cpp unit_test_framework  : : : : array_constexpr ]
+    [ run array6.cpp ]
+    [ run array7.cpp ]
+#    [ run array_constexpr.cpp ]
     [ compile-fail array_getfail1.cpp ]
     [ compile-fail array_getfail2.cpp ]
-    [ run array_hash.cpp unit_test_framework  : : : : array_hash ]
+    [ run array_hash.cpp ]
     ;

--- a/test/array0.cpp
+++ b/test/array0.cpp
@@ -9,15 +9,14 @@
 #include <iostream>
 #include <boost/array.hpp>
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 namespace {
 
 template< class T >
 void    BadValue( const T &  )
 {
-    BOOST_CHECK ( false );
+    BOOST_TEST ( false );
 }
 
 template< class T >
@@ -33,19 +32,19 @@ void    RunTests()
 
     //  front/back and operator[] must compile, but calling them is undefined
     //  Likewise, all tests below should evaluate to false, avoiding undefined behaviour
-    BOOST_CHECK (       test_case.empty());
-    BOOST_CHECK ( const_test_case.empty());
+    BOOST_TEST (       test_case.empty());
+    BOOST_TEST ( const_test_case.empty());
 
-    BOOST_CHECK (       test_case.size() == 0 );
-    BOOST_CHECK ( const_test_case.size() == 0 );
+    BOOST_TEST (       test_case.size() == 0 );
+    BOOST_TEST ( const_test_case.size() == 0 );
 
     //  Assert requirements of TR1 6.2.2.4
-    BOOST_CHECK ( test_case.begin()  == test_case.end());
-    BOOST_CHECK ( test_case.cbegin() == test_case.cend());
-    BOOST_CHECK ( const_test_case.begin() == const_test_case.end());
-    BOOST_CHECK ( const_test_case.cbegin() == const_test_case.cend());
+    BOOST_TEST ( test_case.begin()  == test_case.end());
+    BOOST_TEST ( test_case.cbegin() == test_case.cend());
+    BOOST_TEST ( const_test_case.begin() == const_test_case.end());
+    BOOST_TEST ( const_test_case.cbegin() == const_test_case.cend());
 
-    BOOST_CHECK ( test_case.begin() != const_test_case.begin() );
+    BOOST_TEST ( test_case.begin() != const_test_case.begin() );
     if( test_case.data() == const_test_case.data() ) {
     //  Value of data is unspecified in TR1, so no requirement this test pass or fail
     //  However, it must compile!
@@ -79,11 +78,12 @@ void    RunTests()
 
 }
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
     RunTests< bool >();
     RunTests< void * >();
     RunTests< long double >();
     RunTests< std::string >();
-}
 
+    return boost::report_errors();
+}

--- a/test/array6.cpp
+++ b/test/array6.cpp
@@ -10,8 +10,7 @@
 #include <boost/array.hpp>
 #include <algorithm>
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 namespace {
     template< class T >
@@ -22,19 +21,21 @@ namespace {
         test_type           test_case; //   =   { 1, 1, 2, 3, 5 };
     
         arr &aRef = get_c_array ( test_case );
-        BOOST_CHECK ( &*test_case.begin () == &aRef[0] );
+        BOOST_TEST ( &*test_case.begin () == &aRef[0] );
         
         const arr &caRef = get_c_array ( test_case );
         typename test_type::const_iterator iter = test_case.begin ();
-        BOOST_CHECK ( &*iter == &caRef[0] );
+        BOOST_TEST ( &*iter == &caRef[0] );
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
     RunTests< bool >();
     RunTests< void * >();
     RunTests< long double >();
     RunTests< std::string >();
+
+    return boost::report_errors();
 }
 

--- a/test/array7.cpp
+++ b/test/array7.cpp
@@ -13,8 +13,7 @@
 #include <array>
 #endif
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 namespace {
 
@@ -27,10 +26,10 @@ namespace {
         test_type           test_case; //   =   { 1, 1, 2, 3, 5 };
     
         T &aRef = std::get<0> ( test_case );
-        BOOST_CHECK ( &*test_case.begin () == &aRef );
+        BOOST_TEST ( &*test_case.begin () == &aRef );
         
         const T &caRef = std::get<0> ( test_case );
-        BOOST_CHECK ( &*test_case.cbegin () == &caRef );
+        BOOST_TEST ( &*test_case.cbegin () == &caRef );
     }
     #endif
 
@@ -42,15 +41,15 @@ namespace {
         test_type           test_case; //   =   { 1, 1, 2, 3, 5 };
     
         T &aRef = boost::get<0> ( test_case );
-        BOOST_CHECK ( &*test_case.begin () == &aRef );
+        BOOST_TEST ( &*test_case.begin () == &aRef );
         
         const T &caRef = boost::get<0> ( test_case );
-        BOOST_CHECK ( &*test_case.cbegin () == &caRef );
+        BOOST_TEST ( &*test_case.cbegin () == &caRef );
     }
 
 }
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
     RunBoostTests< bool >();
     RunBoostTests< void * >();
@@ -63,5 +62,7 @@ BOOST_AUTO_TEST_CASE( test_main )
     RunStdTests< long double >();
     RunStdTests< std::string >();
 #endif
+
+    return boost::report_errors();
 }
 

--- a/test/array_constexpr.cpp
+++ b/test/array_constexpr.cpp
@@ -13,9 +13,6 @@
 #include <array>
 #endif
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
-
 #ifndef BOOST_NO_CXX11_CONSTEXPR
 constexpr boost::array<int, 10> arr  {{ 0,1,2,3,4,5,6,7,8,9 }};
 constexpr std::array<int, 10> arr_std {{ 0,1,2,3,4,5,6,7,8,9 }};
@@ -26,7 +23,7 @@ void sink ( T t ) {}
 template <typename T, size_t N>
 void sink ( boost::array<T,N> &arr ) {}
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
 //    constexpr int two = arr_std.at (2);
     constexpr int three = arr.at (3);
@@ -36,7 +33,7 @@ BOOST_AUTO_TEST_CASE( test_main )
 }
 
 #else   // no constexpr means no constexpr tests!
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
 }
 #endif

--- a/test/array_getfail1.cpp
+++ b/test/array_getfail1.cpp
@@ -16,8 +16,7 @@
 #include <array>
 #endif
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 namespace {
 
@@ -30,13 +29,13 @@ namespace {
         test_type           test_case; //   =   { 1, 1, 2, 3, 5 };
     
         T &aRef = std::get<5> ( test_case );    // should fail to compile
-        BOOST_CHECK ( &*test_case.begin () == &aRef );
+        BOOST_TEST ( &*test_case.begin () == &aRef );
     }
     #endif
 
 }
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
 #ifndef BOOST_NO_CXX11_HDR_ARRAY
     RunStdTests< bool >();
@@ -46,4 +45,6 @@ BOOST_AUTO_TEST_CASE( test_main )
 #else
     BOOST_STATIC_ASSERT ( false );  // fail on C++03 systems.
 #endif
+
+    return boost::report_errors();
 }

--- a/test/array_getfail2.cpp
+++ b/test/array_getfail2.cpp
@@ -13,8 +13,7 @@
 #include <array>
 #endif
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 namespace {
 
@@ -27,10 +26,10 @@ namespace {
         test_type           test_case; //   =   { 1, 1, 2, 3, 5 };
     
         T &aRef = std::get<0> ( test_case );
-        BOOST_CHECK ( &*test_case.begin () == &aRef );
+        BOOST_TEST ( &*test_case.begin () == &aRef );
         
         const T &caRef = std::get<0> ( test_case );
-        BOOST_CHECK ( &*test_case.cbegin () == &caRef );
+        BOOST_TEST ( &*test_case.cbegin () == &caRef );
     }
     #endif
 
@@ -42,12 +41,12 @@ namespace {
         test_type           test_case; //   =   { 1, 1, 2, 3, 5 };
     
         T &aRef = boost::get<5> ( test_case );
-        BOOST_CHECK ( &*test_case.begin () == &aRef );
+        BOOST_TEST ( &*test_case.begin () == &aRef );
     }
 
 }
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
     RunBoostTests< bool >();
     RunBoostTests< void * >();
@@ -60,5 +59,7 @@ BOOST_AUTO_TEST_CASE( test_main )
     RunStdTests< long double >();
     RunStdTests< std::string >();
 #endif
+
+    return boost::report_errors();
 }
 

--- a/test/array_hash.cpp
+++ b/test/array_hash.cpp
@@ -11,8 +11,7 @@
 #include <algorithm>
 #include <boost/functional/hash.hpp>
 
-#define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 namespace {
 
@@ -29,15 +28,17 @@ namespace {
     
         std::size_t bhash = boost::hash<barr> () ( test_barr );
         std::size_t ahash = boost::hash<arr>  () ( test_arr );
-        BOOST_CHECK ( ahash == bhash );
+        BOOST_TEST ( ahash == bhash );
     }
 
 }
 
-BOOST_AUTO_TEST_CASE( test_main )
+int main()
 {
     RunTests< int >();
     RunTests< long >();
     RunTests< long double >();
+
+    return boost::report_errors();
 }
 


### PR DESCRIPTION
The tests do not require fully-featured testing framework.
The [lightweight_test](https://www.boost.org/doc/libs/develop/libs/core/doc/html/core/lightweight_test.html) alternative should also save on build times.

-----

Motivation is drawn from recent discussions on #boost channel at cpplang.slack.com, about preferring the lightweight_test wherever possible, also to cut number of inter-dependencies in Boost.