### PR TITLE
Add copyright notice and license text to test program

### DIFF
--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018 Mike Dev
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
 #include <boost/array.hpp>
 
 int main() {


### PR DESCRIPTION
Please the inspect tool which reported the following problems:

### Before

```
bionic:/mnt/d/boost.wsl/libs/array$ inspect -text
Boost Inspection Report
Run Date: 19:16:37 UTC, Thursday 08 August 2019

Totals:
  22 files scanned
  7 directories scanned (including root)
  3 problems reported


Problem counts:
  1 files missing Boost license info or having wrong reference text
  1 files missing copyright notice
  0 files with invalid line endings
  1 files that don't end with a newline
  0 bookmarks with invalid characters
  0 duplicate bookmarks
  0 invalid urls
  0 broken links
  0 unlinked files
  0 file and directory name issues
  0 files with tabs
  0 files with non-ASCII chars
  0 files with Apple macros
  0 files with a C-style assert macro
  0 files with a deprecated BOOST macro
  0 violations of the Boost min/max guidelines
  0 usages of unnamed namespaces in headers (including .ipp files)

Worst Offenders:
test 3

Summary:
  test (3)

Details:
  *Lic* missing Boost license info, or wrong reference text
  *C* missing copyright notice
  *EOL* invalid (cr only) line-ending
  *END* file doesn't end with a newline
  *LINK* invalid bookmarks, duplicate bookmarks, invalid urls, broken links, unlinked files
  *N* file and directory name issues
  *Tabs* tabs in file
  *ASCII* non-ASCII chars in file
  *APPLE-MACROS* calls to Apple's debugging macros in file
  *ASSERT-MACROS* presence of C-style assert macro in file (use BOOST_ASSERT instead)
  *DEPRECATED-MACROS* presence of deprecated BOOST macro in file (see docs for replacements)
  *M* uses of min or max that have not been protected from the min/max macros, or unallowed #undef-s
  *U* unnamed namespace in header

Directories with a file named "boost-no-inspect" will not be inspected.
Files containing "boost-no-inspect" will not be inspected.

|test|
  test/test_cmake/main.cpp:
    *C*
    *END* file doesn't end with a newline
    *Lic*
```

### After

```
bionic:/mnt/d/boost.wsl/libs/array$ inspect -text
Boost Inspection Report
Run Date: 19:39:52 UTC, Thursday 08 August 2019

Totals:
  22 files scanned
  7 directories scanned (including root)
  0 problems reported


Problem counts:
  0 files missing Boost license info or having wrong reference text
  0 files missing copyright notice
  0 files with invalid line endings
  0 files that don't end with a newline
  0 bookmarks with invalid characters
  0 duplicate bookmarks
  0 invalid urls
  0 broken links
  0 unlinked files
  0 file and directory name issues
  0 files with tabs
  0 files with non-ASCII chars
  0 files with Apple macros
  0 files with a C-style assert macro
  0 files with a deprecated BOOST macro
  0 violations of the Boost min/max guidelines
  0 usages of unnamed namespaces in headers (including .ipp files)
```