### PR TITLE
Avoid using deprecated header iterator.hpp

### DIFF
--- a/include/boost/array.hpp
+++ b/include/boost/array.hpp
@@ -41,13 +41,12 @@
 #endif
 
 #include <cstddef>
+#include <iterator>
 #include <stdexcept>
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/swap.hpp>
 
-// Handles broken standard libraries better than <iterator>
-#include <boost/detail/iterator.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 


### PR DESCRIPTION
`<boost/detail/iterator.hpp>` is marked deprecated and is going to be removed in a future release. Replace it with `<iterator>` to avoid deprecation warnings.