### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
           - name: "TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,1 Job 16"
             buildtype: "boost"
             packages: ""
-            os: "macos-10.15"
+            os: "macos-11"
             cxx: "clang++"
             sources: ""
             llvm_os: ""


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22