### PR TITLE
refactor: use core/swap.hpp over boost/swap.hpp

### DIFF
--- a/include/boost/array.hpp
+++ b/include/boost/array.hpp
@@ -44,8 +44,8 @@
 #include <iterator>
 #include <stdexcept>
 #include <boost/assert.hpp>
+#include <boost/core/swap.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/swap.hpp>
 
 #include <boost/throw_exception.hpp>
 #include <algorithm>


### PR DESCRIPTION
The later is deprecated:
```cpp
#ifndef BOOST_SWAP_HPP
#define BOOST_SWAP_HPP

// The header file at this path is deprecated;
// use boost/core/swap.hpp instead.

#include <boost/core/swap.hpp>

#endif

```