### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ matrix:
         - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/assert.git ../assert
         - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/config.git ../config
         - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/core.git ../core
-        - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/static_assert.git ../static_assert
         - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/throw_exception.git ../throw_exception
 
       script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(boost_array
   INTERFACE
     Boost::assert
     Boost::config
-    Boost::static_assert
     Boost::throw_exception
 )
 

--- a/build.jam
+++ b/build.jam
@@ -8,7 +8,6 @@ require-b2 5.2 ;
 constant boost_dependencies :
     /boost/assert//boost_assert
     /boost/config//boost_config
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     ;
 

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -11,7 +11,6 @@ add_subdirectory(../.. boostorg/array)
 add_subdirectory(../../../assert boostorg/assert)
 add_subdirectory(../../../config boostorg/config)
 add_subdirectory(../../../core boostorg/core)
-add_subdirectory(../../../static_assert boostorg/static_assert)
 add_subdirectory(../../../throw_exception boostorg/throw_exception)
 
 add_executable(quick ../quick.cpp)


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.